### PR TITLE
Default modals to not close when clicking background

### DIFF
--- a/app/mixins/ss-modal.js
+++ b/app/mixins/ss-modal.js
@@ -17,7 +17,7 @@ export default Mixin.create(SpreadMixin, SSTransition, {
   // Defaults
   padding: 50,
   offset: 0,
-  closable: true,
+  closable: false,
 
   _isShown: false,
 


### PR DESCRIPTION
Changing this behavior to opt-in; only a few modals should be allowed to close when the background is clicked, and we'll opt into those.

This will be followed up with a PR on manage to actively set some modals to allow the background click-to-close behavior.